### PR TITLE
Rename output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,8 @@ data/raw/*
 data/interim/*.sqlite
 data/interim/*.tsv
 
-# The final data cubes are typically too big to be available on GitHub
-data/processed/cube_*.tsv
-!data/processed/cube_*_taxa_*.tsv
+# The final data cubes are typically too big to be available on GitHub.
+data/processed/*_cube.tsv
+# We remove also the correspondent taxonomic compendiums
+data/processed/*_info.tsv
 .Rproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ data/interim/*.sqlite
 data/interim/*.tsv
 
 # The final data cubes are typically too big to be available on GitHub.
-data/processed/*_cube.tsv
+data/processed/*_cube.csv
 # We remove also the correspondent taxonomic compendiums
-data/processed/*_info.tsv
+data/processed/*_info.csv
 .Rproj.user

--- a/src/4_aggregate.Rmd
+++ b/src/4_aggregate.Rmd
@@ -273,14 +273,14 @@ taxa_species
 
 ## Save aggregated occurrence data
 
-Save the *occurrence data cube* as tab separated text file:
+Save the *occurrence data cube* as comma separated text file:
 
 ```{r save_cube}
 occ_cube_species_filename <- paste0(
-  paste("cube", countries, sep = "_"),
-  ".tsv"
+  paste(countries, "species", "cube", sep = "_"),
+  ".csv"
 )
-write_tsv(occ_cube_species, 
+write_csv(occ_cube_species, 
           here::here("data",
                      "processed",
                      occ_cube_species_filename),
@@ -290,14 +290,14 @@ write_tsv(occ_cube_species,
 
 ## Save taxa
 
-Save the taxa as tab separated text file:
+Save the taxa as comma separated text file:
 
 ```{r save_cube_taxa}
 taxa_species_filename <- paste0(
-  paste("cube", countries, "taxa", sep = "_"),
-  ".tsv"
+  paste(countries, "species", "info", sep = "_"),
+  ".csv"
 )
-write_tsv(taxa_species,
+write_csv(taxa_species,
           path = here::here("data",
                             "processed",
                             taxa_species_filename), na = "")

--- a/src/4_aggregate.Rmd
+++ b/src/4_aggregate.Rmd
@@ -277,7 +277,7 @@ Save the *occurrence data cube* as comma separated text file:
 
 ```{r save_cube}
 occ_cube_species_filename <- paste0(
-  paste(countries, "species", "cube", sep = "_"),
+  paste(str_to_lower(countries), "species", "cube", sep = "_"),
   ".csv"
 )
 write_csv(occ_cube_species, 
@@ -294,7 +294,7 @@ Save the taxa as comma separated text file:
 
 ```{r save_cube_taxa}
 taxa_species_filename <- paste0(
-  paste(countries, "species", "info", sep = "_"),
+  paste(str_to_lower(countries), "species", "info", sep = "_"),
   ".csv"
 )
 write_csv(taxa_species,

--- a/src/4_aggregate.Rmd
+++ b/src/4_aggregate.Rmd
@@ -300,7 +300,10 @@ taxa_species_filename <- paste0(
 write_csv(taxa_species,
           path = here::here("data",
                             "processed",
-                            taxa_species_filename), na = "")
+                            taxa_species_filename),
+          na = "", 
+          quote_escape = FALSE
+)
 ```
 
 Close connection:


### PR DESCRIPTION
This PR:
1. improves names of output files, following style in [trias-project/occ-alien](https://github.com/trias-project/occ-cube-alien). 
2. Change extension output files, from tsv to csv ( see #3).
3. Modify all references to tsv in textual parts of the pipeline (see #3).

These output files are not pushed to remote as they could be very big (e.g. Belgian occurrence cube is ~ 524MB), so they are not visible in "./data/processed". As `processed` subdirectory remains empty, it is also not present on remote.